### PR TITLE
Mixed-Context array checking fails, use Array.isArray

### DIFF
--- a/jsontoxml.js
+++ b/jsontoxml.js
@@ -25,7 +25,7 @@ var process_to_xml = function(node_data,options){
 
   return (function fn(node_data,node_descriptor, level){
     var type = typeof node_data;
-    if(node_data instanceof Array) {
+    if((Array.isArray) ? Array.isArray(node_data) : node_data instanceof Array) {
       type = 'array';
     } else if(node_data instanceof Date) {
       type = 'date';


### PR DESCRIPTION
When data comes in from a different context, data instanceof Array will return false, and render indexed keys as a xml node. (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof)

Array.isArray isn't affected by this.
