### PR TITLE
esc removes invalid xml chars

### DIFF
--- a/jsontoxml.js
+++ b/jsontoxml.js
@@ -4,6 +4,7 @@ var element_start_char =
 	"a-zA-Z_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FFF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD";
 var element_non_start_char = "\-.0-9\u00B7\u0300-\u036F\u203F\u2040"; 
 var element_replace = new RegExp("^([^" + element_start_char + "])|^((x|X)(m|M)(l|L))|([^" + element_start_char + element_non_start_char + "])", "g");
+var not_safe_in_xml = /[^\x09\x0A\x0D\x20-\xFF\x85\xA0-\uD7FF\uE000-\uFDCF\uFDE0-\uFFFD]/gm;
 
 var process_to_xml = function(node_data,options){
 
@@ -179,7 +180,8 @@ function esc(str){
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/'/g, '&apos;')
-      .replace(/"/g, '&quot;');
+      .replace(/"/g, '&quot;')
+      .replace(not_safe_in_xml, '');
 }
 
 module.exports.cdata = cdata;

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ var date = (new Date());
 var input = {
   node:'text content',
   parent:[
-    {name:'taco',text:'beef taco',children:{salsa:'hot!'}},
+    {name:'taco',text:'beef taco',children:{salsa:'hot!'}},
     {name:'xml',text:'tag'},
     {name:'taco',text:'fish taco',attrs:{mood:'sad'},children:[
      {name:'salsa',text:'mild'},


### PR DESCRIPTION
I was having trouble converting data that had invalid unicode chars (usually invisible), such as BACKSPACE (0x08), so I added a `replace` statement to the `esc` function that removes those invalid chars (according to the XML specification (see: https://stackoverflow.com/questions/14665288/removing-invalid-characters-from-xml-before-serializing-it-with-xmlserializer).

I also added to the test data a 0x08 char to make sure it works (although you can't see it in the github diff UI).