### PR TITLE
allow an option 'html'

### DIFF
--- a/jsontoxml.js
+++ b/jsontoxml.js
@@ -17,7 +17,7 @@ var process_to_xml = function(node_data,options){
     }
 
     var node = [indent, '<',name, (attributes || '')];
-    if(content && content.length > 0) {
+    if(content && content.length > 0 || options.html) {
       node.push('>')
       node.push(content);
       hasSubNodes && node.push(indent);


### PR DESCRIPTION
allow an option 'html' to change the behaviour of printing when a tag has no content. For example:
Take for example
```
  {
    "name": "some-tag",
    "text": ""
  }
```
Old output would be:
`<tag/>`

New output would be:
`<tag></tag>`